### PR TITLE
fix: guard against anomalous ask prices in backtest fill engine

### DIFF
--- a/tests/execution/backtest/test_bid_ask_fills.py
+++ b/tests/execution/backtest/test_bid_ask_fills.py
@@ -239,3 +239,32 @@ async def test_position_closed_event_carries_cost_fields() -> None:
     assert ev.exit_commission_cost == pytest.approx(0.5)
 
     dispatcher.unsubscribe(PositionClosedEvent, capture)
+
+
+@pytest.mark.asyncio
+async def test_anomalous_ask_price_falls_back_to_bid(caplog: pytest.LogCaptureFixture) -> None:
+    """Ask prices diverging >5% from bid are treated as corrupted data."""
+    # bid=10250, ask=1.025 simulates corrupted Dukascopy decimal-vs-pipette data
+    client = _client_with_bid_ask(bid_close=10250.0, ask_close=1.025)
+    await client.start()
+
+    with caplog.at_level(logging.WARNING, logger="tradedesk.execution.backtest.client"):
+        result = await client.place_market_order("INST", "BUY", size=1.0)
+
+    # Should fall back to bid-only pricing
+    assert result["price"] == 10250.0
+    assert client.trades[0].spread_cost == 0.0
+    assert client.trades[0].raw_price == 10250.0
+    assert any("Anomalous ask price" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_normal_spread_not_rejected() -> None:
+    """Normal bid/ask spreads within 5% are used as-is."""
+    # ~0.5% spread — well within threshold
+    client = _client_with_bid_ask(bid_close=100.0, ask_close=100.5)
+    await client.start()
+
+    result = await client.place_market_order("INST", "BUY", size=1.0)
+
+    assert result["price"] == 100.5  # fills at ask, not fallback

--- a/tradedesk/execution/backtest/client.py
+++ b/tradedesk/execution/backtest/client.py
@@ -360,6 +360,22 @@ class BacktestClient(Client):
         bid_price = self._get_mark_price(instrument)
         ask_price = self._ask_price.get(instrument)
 
+        # Guard: reject anomalous ask prices (e.g. corrupted Dukascopy data
+        # where prices are in raw decimal instead of pipettes).
+        if ask_price is not None and bid_price != 0:
+            divergence = abs(ask_price - bid_price) / abs(bid_price)
+            if divergence > 0.05:
+                log.warning(
+                    "Anomalous ask price for %s at %s: bid=%.6f ask=%.6f "
+                    "(divergence=%.2f%%); falling back to bid-only pricing",
+                    instrument,
+                    self._current_timestamp,
+                    bid_price,
+                    ask_price,
+                    divergence * 100,
+                )
+                ask_price = None
+
         # Determine executable side
         if ask_price is not None:
             # Bid/ask pricing available


### PR DESCRIPTION
## Summary

- Adds a 5% relative-divergence guard in `_compute_fill_price` — when `|ask - bid| / bid > 0.05`, logs a warning and falls back to bid-only pricing
- Prevents corrupted Dukascopy ask files (raw decimal vs pipettes) from producing wildly incorrect fill prices
- Two new tests covering anomalous detection and normal spread pass-through

## Context

15 out of 5,136 AUDNZD ask data files from Dukascopy have prices in raw decimal format (~1.025) instead of pipettes (~10,250). Discovered during RAD-31 investigation where bid/ask pricing destroyed portfolio alpha (+84,840 → -94,793 PnL).

## Test plan

- [x] mypy --strict: zero errors
- [x] ruff: zero errors
- [x] pytest: 588/588 pass (including 2 new tests)
- [x] QA review approved by Testy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>